### PR TITLE
Enable assembly scanning in DI

### DIFF
--- a/NxRelay.Tests/EventsTest.cs
+++ b/NxRelay.Tests/EventsTest.cs
@@ -20,11 +20,11 @@ public class EventsTest
     public async Task TestSubscribeWithFilterAndPublish()
     {
         bool wasCalled = false;
-        RelayFilter<string> filter = new(message => message.Contains("Test"));
+        RelayFilter<string> filter = new(message => message.Contains("TestSubscribeWithFilterAndPublish"));
 
         _events.Subscribe(_ => wasCalled = true, filter);
 
-        await _events.Publish("Test Message");
+        await _events.Publish("TestSubscribeWithFilterAndPublish");
 
         Assert.That(wasCalled, Is.True, "Event handler should have been called with filtered message.");
 

--- a/NxRelay.Tests/MessagingServiceCollectionExtensionsTests.cs
+++ b/NxRelay.Tests/MessagingServiceCollectionExtensionsTests.cs
@@ -5,12 +5,12 @@ namespace NxRelay.Tests;
 [TestFixture]
 public class MessagingServiceCollectionExtensionsTests
 {
-    private class TestRequest : IRequest<string>
+    public class TestRequest : IRequest<string>
     {
         public string Message { get; init; } = string.Empty;
     }
 
-    private class TestHandler : IRequestHandler<TestRequest, string>
+    public class TestHandler : IRequestHandler<TestRequest, string>
     {
         public ValueTask<string> HandleAsync(TestRequest request, CancellationToken ct)
         {

--- a/NxRelay.Tests/MessagingServiceCollectionExtensionsTests.cs
+++ b/NxRelay.Tests/MessagingServiceCollectionExtensionsTests.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace NxRelay.Tests;
+
+[TestFixture]
+public class MessagingServiceCollectionExtensionsTests
+{
+    private class TestRequest : IRequest<string>
+    {
+        public string Message { get; init; } = string.Empty;
+    }
+
+    private class TestHandler : IRequestHandler<TestRequest, string>
+    {
+        public ValueTask<string> HandleAsync(TestRequest request, CancellationToken ct)
+        {
+            return new ValueTask<string>($"handled:{request.Message}");
+        }
+    }
+
+    [Test]
+    public void AddMessaging_RegistersHandlersFromSpecifiedAssemblies()
+    {
+        ServiceCollection services = new();
+        services.AddMessaging(typeof(TestHandler).Assembly);
+        ServiceProvider provider = services.BuildServiceProvider();
+        IRequestHandler<TestRequest, string>? handler = provider.GetService<IRequestHandler<TestRequest, string>>();
+        Assert.That(handler, Is.Not.Null);
+    }
+}

--- a/NxRelay.Tests/NxRelay.Tests.csproj
+++ b/NxRelay.Tests/NxRelay.Tests.csproj
@@ -15,6 +15,7 @@
         <PackageReference Include="NUnit" Version="3.14.0"/>
         <PackageReference Include="NUnit.Analyzers" Version="3.9.0"/>
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/NxRelay/MessagingServiceCollectionExtensions.cs
+++ b/NxRelay/MessagingServiceCollectionExtensions.cs
@@ -1,53 +1,51 @@
-using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace NxRelay;
 
-/// <summary>
-/// Extension methods for registering messaging services with DI.
-/// </summary>
 public static class MessagingServiceCollectionExtensions
 {
-    // One event aggregator per scope (e.g. per web request,
-    // per game scene, or per job handler)
     /// <summary>
     /// Registers the Events aggregator, Mediator and any discovered handlers in the DI container.
+    /// If you pass one or more <paramref name="extraAssemblies"/>, their
+    /// IRequestHandler&lt;,&gt; and IHandler&lt;&gt; implementations are picked up as well.
     /// </summary>
-    public static IServiceCollection AddMessaging(this IServiceCollection services, params Assembly[] assemblies)
+    public static IServiceCollection AddMessaging(
+        this IServiceCollection services,
+        params Assembly[] extraAssemblies)
     {
         services.AddScoped<Events>();
         services.AddScoped<IMediator, Mediator>();
 
-        if (assemblies is { Length: > 0 })
+        // 1️⃣  Assemblies we always scan: everything that’s part of the current app
+        services.Scan(scan => scan
+            .FromApplicationDependencies()
+            .AddClasses(c => c.AssignableTo(typeof(IHandler<>)))
+            .AsImplementedInterfaces()
+            .WithScopedLifetime());
+
+        services.Scan(scan => scan
+            .FromApplicationDependencies()
+            .AddClasses(c => c.AssignableTo(typeof(IRequestHandler<,>)))
+            .AsImplementedInterfaces()
+            .WithScopedLifetime());
+
+        // 2️⃣  Assemblies supplied explicitly (plugins, test assemblies, etc.)
+        if (extraAssemblies is { Length: > 0 })
         {
-            // open-generic registrations for handlers from provided assemblies
             services.Scan(scan => scan
-                .FromAssemblies(assemblies)
+                .FromAssemblies(extraAssemblies)
                 .AddClasses(c => c.AssignableTo(typeof(IHandler<>)))
                 .AsImplementedInterfaces()
                 .WithScopedLifetime());
 
             services.Scan(scan => scan
-                .FromAssemblies(assemblies)
-                .AddClasses(c => c.AssignableTo(typeof(IRequestHandler<,>)))
-                .AsImplementedInterfaces()
-                .WithScopedLifetime());
-        }
-        else
-        {
-            // fallback to scanning application dependencies
-            services.Scan(scan => scan
-                .FromApplicationDependencies()
-                .AddClasses(c => c.AssignableTo(typeof(IHandler<>)))
-                .AsImplementedInterfaces()
-                .WithScopedLifetime());
-
-            services.Scan(scan => scan
-                .FromApplicationDependencies()
+                .FromAssemblies(extraAssemblies)
                 .AddClasses(c => c.AssignableTo(typeof(IRequestHandler<,>)))
                 .AsImplementedInterfaces()
                 .WithScopedLifetime());
         }
 
         return services;
-    }}
+    }
+}

--- a/NxRelay/MessagingServiceCollectionExtensions.cs
+++ b/NxRelay/MessagingServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
 
 namespace NxRelay;
 
@@ -12,24 +13,41 @@ public static class MessagingServiceCollectionExtensions
     /// <summary>
     /// Registers the Events aggregator, Mediator and any discovered handlers in the DI container.
     /// </summary>
-    public static IServiceCollection AddMessaging(this IServiceCollection services)
+    public static IServiceCollection AddMessaging(this IServiceCollection services, params Assembly[] assemblies)
     {
         services.AddScoped<Events>();
         services.AddScoped<IMediator, Mediator>();
 
-        // open-generic registrations for handlers
-        services.Scan(scan => scan
-            .FromApplicationDependencies()
-            .AddClasses(c => c.AssignableTo(typeof(IHandler<>)))
-            .AsImplementedInterfaces()
-            .WithScopedLifetime());
+        if (assemblies is { Length: > 0 })
+        {
+            // open-generic registrations for handlers from provided assemblies
+            services.Scan(scan => scan
+                .FromAssemblies(assemblies)
+                .AddClasses(c => c.AssignableTo(typeof(IHandler<>)))
+                .AsImplementedInterfaces()
+                .WithScopedLifetime());
 
-        services.Scan(scan => scan
-            .FromApplicationDependencies()
-            .AddClasses(c => c.AssignableTo(typeof(IRequestHandler<,>)))
-            .AsImplementedInterfaces()
-            .WithScopedLifetime());
+            services.Scan(scan => scan
+                .FromAssemblies(assemblies)
+                .AddClasses(c => c.AssignableTo(typeof(IRequestHandler<,>)))
+                .AsImplementedInterfaces()
+                .WithScopedLifetime());
+        }
+        else
+        {
+            // fallback to scanning application dependencies
+            services.Scan(scan => scan
+                .FromApplicationDependencies()
+                .AddClasses(c => c.AssignableTo(typeof(IHandler<>)))
+                .AsImplementedInterfaces()
+                .WithScopedLifetime());
+
+            services.Scan(scan => scan
+                .FromApplicationDependencies()
+                .AddClasses(c => c.AssignableTo(typeof(IRequestHandler<,>)))
+                .AsImplementedInterfaces()
+                .WithScopedLifetime());
+        }
 
         return services;
-    }
-}
+    }}

--- a/NxRelay/MessagingServiceCollectionExtensions.cs
+++ b/NxRelay/MessagingServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ public static class MessagingServiceCollectionExtensions
         services.AddScoped<Events>();
         services.AddScoped<IMediator, Mediator>();
 
-        // 1️⃣  Assemblies we always scan: everything that’s part of the current app
+        //Assemblies we always scan: everything that’s part of the current app
         services.Scan(scan => scan
             .FromApplicationDependencies()
             .AddClasses(c => c.AssignableTo(typeof(IHandler<>)))
@@ -30,8 +30,8 @@ public static class MessagingServiceCollectionExtensions
             .AsImplementedInterfaces()
             .WithScopedLifetime());
 
-        // 2️⃣  Assemblies supplied explicitly (plugins, test assemblies, etc.)
-        if (extraAssemblies is { Length: > 0 })
+        //Assemblies supplied explicitly (plugins, test assemblies, etc.)
+        if (extraAssemblies.Length <= 0 ) return services;
         {
             services.Scan(scan => scan
                 .FromAssemblies(extraAssemblies)

--- a/NxRelay/NxRelay.csproj
+++ b/NxRelay/NxRelay.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>0.0.1</Version>
+        <Version>0.0.15</Version>
         <Title>Nx Relay</Title>
         <Authors>Mohamad Iraji</Authors>
         <Description>NxRelay is a small messaging library that provides two patterns:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Register messaging services in your application startup:
 
 ```csharp
 var services = new ServiceCollection();
-services.AddMessaging();
+// Optionally pass assemblies that contain your handlers
+services.AddMessaging(typeof(MyHandler).Assembly);
 ```
 
 Inject `Events` or `IMediator` where needed and register handlers or publish messages.


### PR DESCRIPTION
## Summary
- allow `AddMessaging` to scan specified assemblies for handlers
- add unit test for scanning assemblies
- document how to pass assemblies to `AddMessaging`
- enable DI library for tests

## Testing
- `dotnet test` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686da2bdaba083318e940370d27baf57